### PR TITLE
Add build definitions for json-c 0.13.1

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -1,0 +1,121 @@
+conf = configuration_data()
+if get_option('rdrand')
+  conf.set10('ENABLE_RDRAND', true)
+endif
+if threads.found()
+  conf.set10('ENABLE_THREADING', true)
+endif
+
+check_headers = [
+  'dlfcn.h',
+  'endian.h',
+  'fcntl.h',
+  'float.h',
+  'inttypes.h',
+  'limits.h',
+  'locale.h',
+  'memory.h',
+  'stdarg.h',
+  'stdint.h',
+  'stdlib.h',
+  'strings.h',
+  'string.h',
+  'syslog.h',
+  'sys/cdefs.h',
+  'sys/param.h',
+  'sys/stat.h',
+  'sys/types.h',
+  'unistd.h',
+  'xlocale.h',
+]
+
+foreach header : check_headers
+  if cc.has_header(header)
+    conf.set10('HAVE_' + header.underscorify().to_upper(), true)
+  endif
+endforeach
+
+stdc = ['stdlib.h', 'stdarg.h', 'string.h', 'float.h']
+have_stdc = true
+foreach header : stdc
+  if not conf.has('HAVE_' + header.underscorify().to_upper())
+    have_stdc = false
+  endif
+endforeach
+conf.set10('STDC_HEADERS', have_stdc)
+
+float_symbols = ['_isnan', '_finite']
+math_symbols = ['INFINITY', 'isinf', 'isnan', 'nan']
+
+foreach symbol : float_symbols
+  if cc.has_header_symbol('float.h', symbol)
+    conf.set10('HAVE_DECL_' + symbol.to_upper(), true)
+  endif
+endforeach
+
+foreach symbol : math_symbols
+  if cc.has_header_symbol('math.h', symbol)
+    conf.set10('HAVE_DECL_' + symbol.to_upper(), true)
+  endif
+endforeach
+
+check_function = [
+  'snprintf',
+  'vasprintf',
+  'vsnprintf',
+  'vprintf',
+  'open',
+  'realloc',
+  'setlocale',
+  'uselocale',
+  'strcasecmp',
+  'strncasecmp',
+  'strdup',
+  'strerror',
+  'vsyslog',
+]
+
+foreach function : check_function
+  if cc.has_function(function)
+    conf.set10('HAVE_' + function.to_upper(), true)
+  endif
+endforeach
+conf.set10('HAVE_DOPRNT', cc.has_function('_doprnt'))
+
+if cc.get_id() == 'msvc'
+  if cc.has_function('strtoll')
+    conf.set10('HAVE_STRTOLL', true)
+    conf.set('json_c_strtoll', 'strtoll')
+  elif cc.has_function('_strtoi64')
+    conf.set10('HAVE_STRTOLL', true)
+    conf.set('json_c_strtoll', '_strtoi64')
+  endif
+endif
+
+check_types = ['int', 'int64_t', 'long', 'long long', 'size_t']
+foreach type : check_types
+  size = cc.sizeof(type, prefix: '#include <stdint.h>')
+  conf.set('SIZEOF_' + type.underscorify().to_upper(), size)
+endforeach
+
+if cc.compiles('int main() { int i, x = 0; i = __sync_add_and_fetch(&x,1); return x; }')
+  conf.set10('HAVE_ATOMIC_BUILTINS', true)
+endif
+
+if cc.compiles('__thread int x = 0; int main() { return 0; }')
+  conf.set10('HAVE___THREAD', true)
+endif
+
+if conf.has('HAVE___THREAD')
+  conf.set('SPEC___THREAD', '__thread')
+elif cc.get_id() == 'msvc'
+  conf.set('SPEC___THREAD', '__declspec(thread)')
+endif
+
+conf.set_quoted('VERSION', meson.project_version())
+
+config_h = configure_file(
+  configuration: conf,
+  output: 'config.h',
+)
+

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,83 @@
+project('json-c', 'c',
+  version: '0.13.1',
+  license: 'MIT',
+  meson_version: '>=0.37',
+  default_options: ['c_std=gnu99'],
+)
+
+cc = meson.get_compiler('c')
+
+add_project_arguments('-D_GNU_SOURCE', language: 'c')
+if cc.has_argument('-Wno-unused')
+  add_project_arguments('-Wno-unused', language: 'c')
+endif
+
+threads = dependency('threads', required: false)
+math = cc.find_library('m', required: false)
+
+subdir('config')
+inc = include_directories('config')
+
+json_config = configuration_data()
+if conf.has('HAVE_INTTYPES_H')
+  json_config.set10('JSON_C_HAVE_INTTYPES_H', true)
+endif
+json_config_h = configure_file(
+  configuration: json_config,
+  output: 'json_config.h',
+)
+
+public_headers = [
+  json_config_h,
+  'arraylist.h',
+  'debug.h',
+  'json_c_version.h',
+  'json_inttypes.h',
+  'json_object.h',
+  'json_pointer.h',
+  'json_tokener.h',
+  'json_util.h',
+  'linkhash.h',
+  'printbuf.h',
+]
+
+sources = [
+  'arraylist.c',
+  'debug.c',
+  'json_c_version.c',
+  'json_object.c',
+  'json_object_iterator.c',
+  'json_pointer.c',
+  'json_tokener.c',
+  'json_util.c',
+  'json_visit.c',
+  'linkhash.c',
+  'printbuf.c',
+  'random_seed.c',
+  'strerror_override.c',
+]
+
+libjson_c = library(meson.project_name(), json_config_h, config_h, sources,
+  include_directories: inc,
+  install: true,
+)
+
+json_c = declare_dependency(
+  link_with: libjson_c,
+  include_directories: include_directories('.'),
+  dependencies: [math, threads],
+  sources: json_config_h,
+)
+
+header_subdir = 'json-c'
+install_headers(public_headers, subdir: header_subdir)
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+  description: 'A JSON implementation in C',
+  libraries: libjson_c,
+  version: meson.project_version(),
+  filebase: meson.project_name(),
+  name: meson.project_name(),
+  subdirs: header_subdir,
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('rdrand', type: 'boolean', value: false, description: 'Enable RDRAND Hardware RNG Hash Seed')

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = json-c-0.13.1
+
+source_url = https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1.tar.gz
+source_filename = json-c-0.13.1.tar.gz
+source_hash = b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873


### PR DESCRIPTION
Based very heavily off of the upstream's CMake build. Most of it is just getting the config.h to be roughly the same between the two.

For an example project using this definition, see https://github.com/ascent12/drm_info. Although that can only be built on Linux.